### PR TITLE
Add bitnami/mongodb-exporter

### DIFF
--- a/mirror-images.list
+++ b/mirror-images.list
@@ -8,3 +8,4 @@ docker://docker.io/centos/php-71-centos7:latest
 docker://docker.io/joeelliott/cert-exporter:latest
 docker://docker.io/postfinance/vault-kubernetes-authenticator:latest
 docker://docker.io/postfinance/vault-kubernetes-synchronizer:latest
+docker://docker.io/bitnami/mongodb-exporter:0.11.2-debian-10-r393


### PR DESCRIPTION
The bitnami/mongodb-exporter:0.11.2-debian-10-r393 image is used by CI Dashboard downstream.